### PR TITLE
Improved default meta-viewport setting and set html language to English

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -5,6 +5,7 @@ export default function App({ Component, pageProps }) {
   return (
     <>
       <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,16 @@
+
+import Document, { Head, Main, NextScript, Html } from 'next/document'
+
+export default class MyDocument extends Document {
+  render() {
+    return (
+      <Html lang="en">
+        <Head />
+        <body>
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    )
+  }
+}


### PR DESCRIPTION
## Problem/motivation
1. Default Next.js viewport meta tag doesn't include `initial-scale=1` sub-setting.
From [Google's Web Fundamentals](https://developers.google.com/web/fundamentals/design-and-ux/responsive):
> Include `initial-scale=1` to establish a 1:1 relationship between CSS pixels and device-independent pixels.
2. The `<html>` element of the default document markup does not have a [lang] attribute.
From Chrome Dev Tools -> Audits -> Accessibility:
> If a page doesn't specify a lang attribute, a screen reader assumes that the page is in the default language that the user chose when setting up the screen reader. If the page isn't actually in the default language, then the screen reader might not announce the page's text correctly.

## Proposed resolution

Add necessary meta data.

## Actions taken

1. Overridden the default `_document.js` template in order to add `html[lang]=en`. Hopefully, the Next.js maintainers [will add](https://github.com/zeit/next.js/issues/9160) the lang attribute by default soon but for now it's the only solution.
2. Improved the meta-viewport tag to follow best practices of responsive design. See PR's change log for more details.