### PR TITLE
Included XML sitemap generation into the build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && next export && cp _redirects out/_redirects",
+    "build": "next build && next export && node tools/generate-sitemap.js && cp _redirects out/_redirects",
     "start": "next start"
   },
   "dependencies": {
@@ -16,6 +16,7 @@
     "front-matter": "^3.2.1",
     "marked": "^1.0.0",
     "next": "9.4.0",
+    "nextjs-sitemap-generator": "^1.0.0",
     "postcss-nesting": "^7.0.1",
     "react": "16.13.1",
     "react-dom": "16.13.1",

--- a/tools/generate-sitemap.js
+++ b/tools/generate-sitemap.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const sitemap = require('nextjs-sitemap-generator');
+
+// @todo: Extract base url to the main site config.
+sitemap({
+  baseUrl: 'https://jobs.tailwindui.com',
+  ignoredPaths: [],
+  extraPaths: ['/'],
+  pagesDirectory: 'jobs',
+  targetDirectory : 'out',
+  pagesConfig: {
+    '/': { priority: '1', changefreq: 'daily' },
+  },
+});
+
+console.log(`✅ sitemap.xml has been generated.`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2356,7 +2356,7 @@ data-uri-to-buffer@3.0.0:
   dependencies:
     buffer-from "^1.1.1"
 
-date-fns@^2.13.0:
+date-fns@^2.13.0, date-fns@^2.9.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.13.0.tgz#d7b8a0a2d392e8d88a8024d0a46b980bbfdbd708"
   integrity sha512-xm0c61mevGF7f0XpCGtDTGpzEFC/1fpLXHbmFpxZZQJuvByIK2ozm6cSYuU+nxFYOPh2EuCfzUwlTEFwKG+h5w==
@@ -4060,6 +4060,13 @@ next@9.4.0:
     web-vitals "0.2.1"
     webpack "4.43.0"
     webpack-sources "1.4.3"
+
+nextjs-sitemap-generator@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nextjs-sitemap-generator/-/nextjs-sitemap-generator-1.0.0.tgz#88227fea24a055f0d9031bfe4ce303bf537b24b1"
+  integrity sha512-4M5nC2FA1Mf1sDDPQ+a1OJB5iFXjRUuhfQ+V9wVEl8ydzV2jQU6j0lABy+4cHm6KPmQr7ikq3JwOxusbB9nK1w==
+  dependencies:
+    date-fns "^2.9.0"
 
 node-emoji@^1.8.1:
   version "1.10.0"


### PR DESCRIPTION
## Problem/motivation

Having an XML sitemap and submitting it to Google Search Console is considered a SEO best practice.

From [Google Help Center](https://support.google.com/webmasters/answer/156184):

> You might need a sitemap if:
Your site is new and has few external links to it. Googlebot and other web crawlers crawl the web by following links from one page to another. As a result, Google might not discover your pages if no other sites link to them.

> Using a sitemap doesn't guarantee that all the items in your sitemap will be crawled and indexed, as Google processes rely on complex algorithms to schedule crawling. However, in most cases, your site will benefit from having a sitemap, and you'll never be penalized for having one.

## Proposed resolution

Create a script that would generate the sitemap and include it into the project build pipeline.

## Actions taken

- [x] Installed [nextjs-sitemap-generator](https://github.com/IlusionDev/nextjs-sitemap-generator.git).
- [x] Created `tools/generate-sitemap.js` script.
- [x] Included the script into the project build pipeline.
- [ ] Create project config with the site base url and use the added constant in the `generate-sitemap.js` script.
- [ ] __To maintainer: When you rebuild and deploy the site next time, please submit the https://jobs.tailwindui.com/sitemap.xml to Google Search Console.__
